### PR TITLE
Transition image to use node 6 to match AWS Lambda's architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:boron
 
 RUN set -ex \
     && apt-get update \
@@ -6,13 +6,6 @@ RUN set -ex \
         python-setuptools \
         python-dev \
     && easy_install pip \
-    && pip install awscli \
-    && wget -O /usr/local/bin/assume-role https://github.com/remind101/assume-role/releases/download/0.3.2/assume-role-Linux \
-    && echo 'cc41ea5de3e27557481c74efacc368c8a8786e65  /usr/local/bin/assume-role' | sha1sum -c - \
-    && chmod 0744 /usr/local/bin/assume-role \
-    && wget https://github.com/awslabs/aws-sam-local/releases/download/v0.2.0/sam_0.2.0_linux_amd64.tar.gz \
-    && echo '1784bca0c9f29f4d3a57f095c7ebda701ddc0467  sam_0.2.0_linux_amd64.tar.gz' | sha1sum -c - \
-    && tar -xzf sam_0.2.0_linux_amd64.tar.gz -C /usr/local/bin \
-    && rm sam_0.2.0_linux_amd64.tar.gz
+    && pip install awscli
 
 USER node

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,4 @@
-# serverless
+# node-lambda
 
-Dockerfile that starts with the node image and adds [assume-role](https://github.com/remind101/assume-role). We use it for deploying [Serverless](https://github.com/serverless/serverless) apps.
+Dockerfile which adds the AWS CLI tool set to the node base image. Contrast
+Security uses the image to deploy node.js code to AWS Lambda


### PR DESCRIPTION
Use Node 6 to match AWS Lambda architecture. Remove unused tool chain components sam-local and assume role